### PR TITLE
Timer fix-2025-01-04

### DIFF
--- a/scenes/levels/common/level.tscn
+++ b/scenes/levels/common/level.tscn
@@ -66,4 +66,20 @@ offset_bottom = 48.0
 pivot_offset = Vector2(32, 0)
 icon = ExtResource("3_qnfjt")
 
+[node name="Timers" type="Node" parent="."]
+
+[node name="Start Timer" type="Timer" parent="Timers"]
+wait_time = 10.0
+one_shot = true
+autostart = true
+
+[node name="Wave Timer" type="Timer" parent="Timers"]
+wait_time = 5.0
+one_shot = true
+
+[node name="Spawn Timer" type="Timer" parent="Timers"]
+one_shot = true
+
 [connection signal="pressed" from="UserInterface/Menu/Button" to="." method="_on_menu_button_pressed"]
+[connection signal="timeout" from="Timers/Start Timer" to="." method="fight_state"]
+[connection signal="timeout" from="Timers/Wave Timer" to="." method="_on_wave_timer_timeout"]

--- a/scenes/levels/level_1/level_1.gd
+++ b/scenes/levels/level_1/level_1.gd
@@ -17,12 +17,12 @@ signal player_ended_tutorial()
 
 
 # Common
-func idle_state(_duration):
+func idle_state():
+	SoundManager.music_idle.play()
 	tutorial()
 
 func tutorial():
 	# Get ready
-	SoundManager.music_idle.play()
 	var hint = hint_scene.instantiate()
 	add_child(hint)
 	# Greet

--- a/units/common/unit.gd
+++ b/units/common/unit.gd
@@ -17,9 +17,11 @@ enum States {
 
 
 @onready var shell_container = get_tree().get_current_scene().get_node("Shell Container")
+
 @onready var animated_sprite_2d = $AnimatedSprite2D
 @onready var animation_player = $AnimationPlayer
 @onready var collision_shape_2d = $Area2D/CollisionShape2D
+@onready var find_timer = $"Find Timer"
 
 @onready var attack_sfx = $SFX/Attack
 
@@ -34,7 +36,7 @@ enum States {
 
 
 
-var available_enemies: Array = []
+var available_enemies: Array[Enemy] = []
 
 var target: Enemy
 
@@ -46,7 +48,8 @@ var state: int:
 				idle_state()
 			States.ATTACK:
 				# Give the unit some time to find all available enemies
-				await get_tree().create_timer(0.1).timeout
+				find_timer.start()
+				await find_timer.timeout
 				# If there are still available enemies
 				if available_enemies:
 					attack_state()
@@ -101,7 +104,7 @@ func _on_area_2d_body_entered(body):
 
 func _on_area_2d_body_exited(body):
 	available_enemies.erase(body)
-	# If target died or ran away and there are available enemies and not cooldown
+	# If target died or ran away and there are available enemies and not cooldown,
 	# Choose a new target
 	if target == body and available_enemies and state != States.COOLDOWN:
 		attack_state()

--- a/units/common/unit.tscn
+++ b/units/common/unit.tscn
@@ -30,6 +30,7 @@ editor_description = "Find Timer is designed to give a unit some time to find al
 When a unit find an enemy, he immediately starts shooting and he start shooting the first enemy he saw and he doesn't even check which target is better because at the moment the unit found an enemy variable \"available enemies: Array[Enemy]\" has only one item. For the next time the unit shoots, he chooses the best target.
 
 It can be reproduced: 1. Let 2 or more enemies be in the attack range of units (the tower mustn't be built yet). 2. Build a tower so that there is more than one enemy is in the attack range of the units. For the first time, the units often chooses not the best target (the best target is not a dying enemy closest to the Holy Oak)"
+wait_time = 0.1
 
 [connection signal="body_entered" from="Area2D" to="." method="_on_area_2d_body_entered"]
 [connection signal="body_exited" from="Area2D" to="." method="_on_area_2d_body_exited"]

--- a/units/common/unit.tscn
+++ b/units/common/unit.tscn
@@ -24,5 +24,12 @@ bus = &"SFX"
 [node name="Attack" type="AudioStreamPlayer2D" parent="SFX"]
 bus = &"SFX"
 
+[node name="Find Timer" type="Timer" parent="."]
+editor_description = "Find Timer is designed to give a unit some time to find all enemies.
+
+When a unit find an enemy, he immediately starts shooting and he start shooting the first enemy he saw and he doesn't even check which target is better because at the moment the unit found an enemy variable \"available enemies: Array[Enemy]\" has only one item. For the next time the unit shoots, he chooses the best target.
+
+It can be reproduced: 1. Let 2 or more enemies be in the attack range of units (the tower mustn't be built yet). 2. Build a tower so that there is more than one enemy is in the attack range of the units. For the first time, the units often chooses not the best target (the best target is not a dying enemy closest to the Holy Oak)"
+
 [connection signal="body_entered" from="Area2D" to="." method="_on_area_2d_body_entered"]
 [connection signal="body_exited" from="Area2D" to="." method="_on_area_2d_body_exited"]


### PR DESCRIPTION
# What's Changed
* Add node timers instead tree timers for units

## Issues
* https://github.com/raven-xr/HolyOak-game/issues/34

## Major changes
* Add node timers instead tree timers for units and levels because tree timers couldn't be paused. It caused some problems

## Minor changes
* Replace emit_signal() with signal_name.emit()
* Remove the useless "number" variable from the "new_wave()" function
* Define the type of items of the "available_enemies" variable as "Array[Enemy]"