### PR TITLE
Preattack Freeze Anim Fix-2025-01-04

### DIFF
--- a/units/common/unit.gd
+++ b/units/common/unit.gd
@@ -54,6 +54,7 @@ var state: int:
 				if available_enemies:
 					attack_state()
 				else:
+					idle_state()
 					state = States.IDLE
 			States.COOLDOWN:
 				cooldown_state()


### PR DESCRIPTION
# What's Changed
* Fix a bug where units still gets stuck in the cooldown animation

## Issues
* #38 

## Major changes
* Add the "idle_state()" string to the state machine

## Problem
The bug was caused with the fact that setters aren't triggered by their own functions